### PR TITLE
Fix typo in docker run command

### DIFF
--- a/connect_your_app_to_IRIS/technical_details/app_onboarding.md
+++ b/connect_your_app_to_IRIS/technical_details/app_onboarding.md
@@ -130,7 +130,7 @@ If you are on Linux command line and defined it above, you could simply use the 
 
 You can start a local eps with
 
-    docker run --name iris-eps -p 5556:5556 -p 4444:4444 -v "/data/eps/certs:/app/settings/certs" :ro --env-file .env inoeg/app-eps:latest
+    docker run --name iris-eps -p 5556:5556 -p 4444:4444 -v "/data/eps/certs:/app/settings/certs":ro --env-file .env inoeg/app-eps:latest
 
 Port 4444, 4443 or 443 are valid for test environment. 
 


### PR DESCRIPTION
Space before :ro in volume attribute causes syntax error (docker: invalid reference format).